### PR TITLE
Add plotsquared protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,18 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.intellectualsites.bom</groupId>
+                <artifactId>bom-newest</artifactId>
+                <version>1.48</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
@@ -149,6 +161,12 @@
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
             <version>0.100.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.intellectualsites.plotsquared</groupId>
+            <artifactId>plotsquared-core</artifactId>
+            <version>7.3.8</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/youhavetrouble/yardwatch/YardWatch.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/YardWatch.java
@@ -5,6 +5,7 @@ import me.youhavetrouble.yardwatch.commands.YardWatchCommand;
 import me.youhavetrouble.yardwatch.hooks.FactionsUUIDProtection;
 import me.youhavetrouble.yardwatch.hooks.GriefPreventionProtection;
 import me.youhavetrouble.yardwatch.hooks.LWCXProtection;
+import me.youhavetrouble.yardwatch.hooks.PlotSquaredProtection;
 import me.youhavetrouble.yardwatch.hooks.SuperiorSkyBlockProtection;
 import me.youhavetrouble.yardwatch.hooks.TownyProtection;
 import me.youhavetrouble.yardwatch.hooks.WorldGuardProtection;
@@ -80,6 +81,13 @@ public final class YardWatch extends JavaPlugin {
             getLogger().info("Registering Towny service.");
             getServer().getServicesManager().register(
                     Protection.class, new TownyProtection(this), this, ServicePriority.Normal
+            );
+        }
+
+        if (shouldRegisterService("PlotSquared")) {
+            getLogger().info("Registering PlotSquared service.");
+            getServer().getServicesManager().register(
+                    Protection.class, new PlotSquaredProtection(this), this, ServicePriority.Normal
             );
         }
 

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
@@ -29,7 +29,7 @@ public class PlotSquaredProtection implements Protection {
 
         final com.plotsquared.core.location.Location arg1 = getLocation(location);
 
-        return arg1.isPlotArea() || arg1.isPlotRoad() || arg1.isUnownedPlotArea();
+        return arg1.isPlotArea() || arg1.isPlotRoad() || arg1.isUnownedPlotArea() || arg1.getOwnedPlot() != null;
     }
 
     @Override

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
@@ -41,17 +41,13 @@ public class PlotSquaredProtection implements Protection {
 
         final Plot plot = location.getOwnedPlot();
 
-        // if plot null, revert to isProtected check, we might have getOwnedPlot() != null in the method, but obviously
-        // isProtected will be used in other places.
         if (plot == null) return isProtected(blockLocation);
 
-        // Check if the player is added to the plot including members or trusted or if they are owner
         return plot.isAdded(player.getUniqueId());
     }
 
     @Override
     public boolean canPlaceBlock(final Player player, final Location location) {
-        // the code to handle canBreakBlock is simply checking if added to plot anyway.
         return canBreakBlock(player, location.getBlock().getState());
     }
 
@@ -72,7 +68,6 @@ public class PlotSquaredProtection implements Protection {
 
     @Override
     public boolean canInteract(final Player player, final Entity target) {
-        // use the above method instead, code the same.
         return canInteract(player, target.getLocation().getBlock().getState());
     }
 
@@ -88,7 +83,6 @@ public class PlotSquaredProtection implements Protection {
 
         if (plot == null) return isProtected(location);
 
-        // if location is protected, consider it a safezone.
         return plot.getFlag(PvpFlag.class);
     }
 

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
@@ -1,0 +1,100 @@
+package me.youhavetrouble.yardwatch.hooks;
+
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.flag.implementations.PvpFlag;
+import me.youhavetrouble.yardwatch.Protection;
+import me.youhavetrouble.yardwatch.YardWatch;
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class PlotSquaredProtection implements Protection {
+
+    private final YardWatch plugin;
+
+    public PlotSquaredProtection(YardWatch plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.plugin.getServer().getPluginManager().isPluginEnabled("PlotSquared");
+    }
+
+    @Override
+    public boolean isProtected(final Location location) {
+        if (!isEnabled()) return false;
+
+        final com.plotsquared.core.location.Location arg1 = getLocation(location);
+
+        return arg1.isPlotArea() || arg1.isPlotRoad() || arg1.isUnownedPlotArea();
+    }
+
+    @Override
+    public boolean canBreakBlock(final Player player, final BlockState blockState) {
+        if (!isEnabled()) return true;
+
+        final Location blockLocation = blockState.getLocation();
+        final com.plotsquared.core.location.@NonNull Location location = getLocation(blockLocation);
+
+        final Plot plot = location.getOwnedPlot();
+
+        // if plot null, revert to isProtected check, we might have getOwnedPlot() != null in the method, but obviously
+        // isProtected will be used in other places.
+        if (plot == null) return isProtected(blockLocation);
+
+        // Check if the player is added to the plot including members or trusted or if they are owner
+        return plot.isAdded(player.getUniqueId());
+    }
+
+    @Override
+    public boolean canPlaceBlock(final Player player, final Location location) {
+        // the code to handle canBreakBlock is simply checking if added to plot anyway.
+        return canBreakBlock(player, location.getBlock().getState());
+    }
+
+    @Override
+    public boolean canInteract(final Player player, final BlockState blockState) {
+        if (!isEnabled()) return true;
+
+        final Location location = blockState.getLocation();
+
+        com.plotsquared.core.location.@NonNull Location plotLocation = getLocation(location);
+
+        final Plot plot = plotLocation.getOwnedPlot();
+
+        // if location is protected, consider it a place you can't interact with
+        return isProtected(location) || plot != null && plot.isAdded(player.getUniqueId());
+    }
+
+    @Override
+    public boolean canInteract(final Player player, final Entity target) {
+        // use the above method instead, code the same.
+        return canInteract(player, target.getLocation().getBlock().getState());
+    }
+
+    @Override
+    public boolean canDamage(final Entity damager, final Entity target) {
+        if (!isEnabled() || !(damager instanceof Player)) return true;
+
+        final Location location = target.getLocation();
+
+        com.plotsquared.core.location.@NonNull Location plotLocation = getLocation(location);
+
+        final Plot plot = plotLocation.getOwnedPlot();
+
+        // if location is protected, consider it a safezone.
+        return isProtected(location) || plot != null && plot.getFlag(PvpFlag.class);
+    }
+
+    private com.plotsquared.core.location.@NonNull Location getLocation(final Location location) {
+        final String world = location.getWorld().getName();
+        final int x = (int) location.getX();
+        final int y = (int) location.getY();
+        final int z = (int) location.getZ();
+
+        return com.plotsquared.core.location.Location.at(world, x, y, z);
+    }
+}

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
@@ -46,7 +46,7 @@ public class PlotSquaredProtection implements Protection {
         if (plot == null) return isProtected(blockLocation);
 
         // Check if the player is added to the plot including members or trusted or if they are owner
-        return plot.isAdded(player.getUniqueId());
+        return isProtected(blockLocation) || plot.isAdded(player.getUniqueId());
     }
 
     @Override

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/PlotSquaredProtection.java
@@ -46,7 +46,7 @@ public class PlotSquaredProtection implements Protection {
         if (plot == null) return isProtected(blockLocation);
 
         // Check if the player is added to the plot including members or trusted or if they are owner
-        return isProtected(blockLocation) || plot.isAdded(player.getUniqueId());
+        return plot.isAdded(player.getUniqueId());
     }
 
     @Override
@@ -65,8 +65,9 @@ public class PlotSquaredProtection implements Protection {
 
         final Plot plot = plotLocation.getOwnedPlot();
 
-        // if location is protected, consider it a place you can't interact with
-        return isProtected(location) || plot != null && plot.isAdded(player.getUniqueId());
+        if (plot == null) return isProtected(location);
+
+        return plot.isAdded(player.getUniqueId());
     }
 
     @Override
@@ -85,8 +86,10 @@ public class PlotSquaredProtection implements Protection {
 
         final Plot plot = plotLocation.getOwnedPlot();
 
+        if (plot == null) return isProtected(location);
+
         // if location is protected, consider it a safezone.
-        return isProtected(location) || plot != null && plot.getFlag(PvpFlag.class);
+        return plot.getFlag(PvpFlag.class);
     }
 
     private com.plotsquared.core.location.@NonNull Location getLocation(final Location location) {

--- a/src/main/java/me/youhavetrouble/yardwatch/hooks/TownyProtection.java
+++ b/src/main/java/me/youhavetrouble/yardwatch/hooks/TownyProtection.java
@@ -3,7 +3,6 @@ package me.youhavetrouble.yardwatch.hooks;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyPermission;
 import com.palmergames.bukkit.towny.utils.CombatUtil;
 import me.youhavetrouble.yardwatch.Protection;
 import me.youhavetrouble.yardwatch.YardWatch;
@@ -45,7 +44,7 @@ public class TownyProtection implements Protection {
 
     @Override
     public boolean canPlaceBlock(Player player, Location location) {
-        return canInteract(player, location.getBlock().getState(true));
+        return canInteract(player, location.getBlock().getState());
     }
 
     @Override
@@ -63,7 +62,7 @@ public class TownyProtection implements Protection {
 
     @Override
     public boolean canInteract(Player player, Entity target) {
-        return canInteract(player, target.getLocation().getBlock().getState(true));
+        return canInteract(player, target.getLocation().getBlock().getState());
     }
 
     @Override


### PR DESCRIPTION
This does add PlotSquared support, however... it feels wrong.

PlotSquared does have a Flags system, but the flags confuse me. The way I check if you currently can break or place blocks is simply by seeing if someone added you to the plot which implies you are trusted, an owner, or a member of. I also check if the location isProtected first, which implies they can't do anything anyway.

The same was applied to both canInteract methods. ~~Do you want it flag based? https://intellectualsites.gitbook.io/plotsquared/api/flag-api~~

The way it is now, it should function.

**A little misc change:**
getState(true) is pointless